### PR TITLE
Add optional 'container' prop to Package. Fix USPS ServerErrors never pa...

### DIFF
--- a/src/DotNetShipping/Package.cs
+++ b/src/DotNetShipping/Package.cs
@@ -17,7 +17,8 @@ namespace DotNetShipping
 		/// <param name = "height">The height of the package, in inches.</param>
 		/// <param name = "weight">The weight of the package, in pounds.</param>
 		/// <param name = "insuredValue">The insured-value of the package, in dollars.</param>
-		public Package(int length, int width, int height, int weight, decimal insuredValue) : this(length, width, height, (decimal) weight, insuredValue)
+        /// <param name = "container">A specific packaging from a shipping provider. E.g. "LG FLAT RATE BOX" for USPS</param>
+		public Package(int length, int width, int height, int weight, decimal insuredValue, string container = null) : this(length, width, height, (decimal) weight, insuredValue, container)
 		{
 		}
 
@@ -29,13 +30,15 @@ namespace DotNetShipping
 		/// <param name = "height">The height of the package, in inches.</param>
 		/// <param name = "weight">The weight of the package, in pounds.</param>
 		/// <param name = "insuredValue">The insured-value of the package, in dollars.</param>
-		public Package(decimal length, decimal width, decimal height, decimal weight, decimal insuredValue)
+        /// <param name = "container">A specific packaging from a shipping provider. E.g. "LG FLAT RATE BOX" for USPS</param>
+        public Package(decimal length, decimal width, decimal height, decimal weight, decimal insuredValue, string container = null)
 		{
 			Length = length;
 			Width = width;
 			Height = height;
 			Weight = weight;
 			InsuredValue = insuredValue;
+            Container = container;
 		}
 
 		#endregion
@@ -73,6 +76,7 @@ namespace DotNetShipping
 		}
 		public decimal Weight { get; set; }
 		public decimal Width { get; set; }
+        public string Container { get; set; }
 
 		#endregion
 	}

--- a/src/DotNetShipping/ShippingProviders/USPSInternationalProvider.cs
+++ b/src/DotNetShipping/ShippingProviders/USPSInternationalProvider.cs
@@ -175,12 +175,12 @@ namespace DotNetShipping.ShippingProviders
 		    }
 
 		    //check for errors
-		    if (document.Elements("Error").Any())
+            if (document.Descendants("Error").Any())
 		    {
 		        var errors = from item in document.Descendants("Error")
 		            select new USPSError()
 		            {
-		                Description = item.Element("Number").ToString(),
+                        Description = item.Element("Description").ToString(),
                         Source = item.Element("Source").ToString(),
                         HelpContext = item.Element("HelpContext").ToString(),
                         HelpFile = item.Element("HelpFile").ToString(),


### PR DESCRIPTION
...rsing. USPSProvider: Add GetRates() baseRatesOnly param to turn of Revision=2. Detect LARGE packages based on dimensions or Package.IsOversized. Force valid container values when Package is LARGE. Set "Machinable" based on package dims.

This passes with the previously passing unit tests with the exception of the two USPS_Intl_Returns_No_Rates... The failure is caused by Assert.Empty(response.ServerErrors). The providers were not previously capable of parsing the Error element, so I'm not sure this is a good assertion anymore. Anyways, I want to get ServerErrors.
