### PR TITLE
Added ability to choose to use test or prod FedEx web services

### DIFF
--- a/src/DotNetShipping/DotNetShipping.csproj
+++ b/src/DotNetShipping/DotNetShipping.csproj
@@ -64,6 +64,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Address.cs" />
+    <Compile Include="FedExRateService.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Extensions.cs" />
     <Compile Include="IRateAdjuster.cs" />

--- a/src/DotNetShipping/FedExRateService.cs
+++ b/src/DotNetShipping/FedExRateService.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace DotNetShipping.RateServiceWebReference 
+{
+    public partial class RateService
+    {
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="production"></param>
+        public RateService(bool production) 
+        {
+            if (production == true)
+            {
+                this.Url = "https://ws.fedex.com:443/web-services/rate";
+            }
+            else
+            {
+                this.Url = "https://wsbeta.fedex.com:443/web-services";
+            }
+
+            if ((this.IsLocalFileSystemWebService(this.Url) == true)) {
+                this.UseDefaultCredentials = true;
+                this.useDefaultCredentialsSetExplicitly = false;
+            }
+            else {
+                this.useDefaultCredentialsSetExplicitly = true;
+            }
+        }
+    }
+}

--- a/src/DotNetShipping/ShippingProviders/FedExProvider.cs
+++ b/src/DotNetShipping/ShippingProviders/FedExProvider.cs
@@ -21,6 +21,7 @@ namespace DotNetShipping.ShippingProviders
 		private readonly string _key;
 		private readonly string _meterNumber;
 		private readonly string _password;
+	    private readonly bool _production;
 
 		private readonly Dictionary<string, string> _serviceCodes = new Dictionary<string, string>
 		                                                            	{
@@ -51,6 +52,7 @@ namespace DotNetShipping.ShippingProviders
 			_password = appSettings["FedExPassword"];
 			_accountNumber = appSettings["FedExAccountNumber"];
 			_meterNumber = appSettings["FedExMeterNumber"];
+		    _production = true;
 		}
 
 		///<summary>
@@ -59,7 +61,8 @@ namespace DotNetShipping.ShippingProviders
 		///<param name = "password"></param>
 		///<param name = "accountNumber"></param>
 		///<param name = "meterNumber"></param>
-		public FedExProvider(string key, string password, string accountNumber, string meterNumber)
+        ///<param name = "production"></param>
+        public FedExProvider(string key, string password, string accountNumber, string meterNumber, bool production)
 		{
 			Name = "FedEx";
 
@@ -67,6 +70,7 @@ namespace DotNetShipping.ShippingProviders
 			_password = password;
 			_accountNumber = accountNumber;
 			_meterNumber = meterNumber;
+		    _production = production;
 		}
 
 		#endregion
@@ -76,7 +80,7 @@ namespace DotNetShipping.ShippingProviders
 		public override void GetRates()
 		{
 			RateRequest request = CreateRateRequest();
-			var service = new RateService();
+			var service = new RateService(_production);
 			try
 			{
 				// Call the web service passing in a RateRequest and returning a RateReply

--- a/src/SampleApp/Program.cs
+++ b/src/SampleApp/Program.cs
@@ -45,7 +45,7 @@ namespace DotNetShipping.SampleApp
 
 			// Add desired DotNetShippingProviders
 			rateManager.AddProvider(new UPSProvider(upsLicenseNumber, upsUserId, upsPassword));
-			rateManager.AddProvider(new FedExProvider(fedexKey, fedexPassword, fedexAccountNumber, fedexMeterNumber));
+			rateManager.AddProvider(new FedExProvider(fedexKey, fedexPassword, fedexAccountNumber, fedexMeterNumber, true));
 			rateManager.AddProvider(new USPSProvider(uspsUserId));
             //rateManager.AddProvider(new USPSInternationalProvider(uspsUserId));
             


### PR DESCRIPTION
I added another constructor when creating the web service instance to allow the selection of test or prod FedEx webservices instead of having to modify the config file. This allows the ability to call test or prod FedEx rates in the same application.
