### PR TITLE
Using PoundsAndOunces in USPSInternationalProvider

### DIFF
--- a/DotNetShipping/ShippingProviders/USPSInternationalProvider.cs
+++ b/DotNetShipping/ShippingProviders/USPSInternationalProvider.cs
@@ -135,8 +135,8 @@ namespace DotNetShipping.ShippingProviders
 
                     writer.WriteStartElement("Package");
                     writer.WriteAttributeString("ID", i.ToString());
-                    writer.WriteElementString("Pounds", package.RoundedWeight.ToString());
-                    writer.WriteElementString("Ounces", "0");
+                    writer.WriteElementString("Pounds", package.PoundsAndOunces.Pounds.ToString());
+                    writer.WriteElementString("Ounces", package.PoundsAndOunces.Ounces.ToString());
                     writer.WriteElementString("MailType", "Package");
                     writer.WriteElementString("ValueOfContents", package.InsuredValue < 0 ? package.InsuredValue.ToString() : "100"); //todo: figure out best way to come up with insured value
                     writer.WriteElementString("Country", Shipment.DestinationAddress.GetCountryName());


### PR DESCRIPTION
We noticed some issues with small packages usind USPSInternationalProvider. Especially for items such as CD or books. Sometimes they weight less than a pound.

At the moment the provider sends the `RoundedWeight` to the API, it can't be lower than 1.

This PR replaces the `RoundedWeight` usage by the appropriate Pounds and Ounces values.