### PR TITLE
Added the ability to tack on charges if a package requires a signature...

### DIFF
--- a/DotNetShipping.Tests/Features/USPSDomesticRates.cs
+++ b/DotNetShipping.Tests/Features/USPSDomesticRates.cs
@@ -15,6 +15,7 @@ namespace DotNetShipping.Tests.Features
         private readonly Address DomesticAddress2;
         private readonly Address InternationalAddress1;
         private readonly Package Package1;
+        private readonly Package Package1SignatureRequired;
         private readonly string USPSUserId;
 
         public USPSDomesticRates()
@@ -24,7 +25,8 @@ namespace DotNetShipping.Tests.Features
             InternationalAddress1 = new Address("Jubail", "Jubail", "31951", "Saudi Arabia");
 
             Package1 = new Package(4, 4, 4, 5, 0);
-            Package1 = new Package(6, 6, 6, 5, 100);
+            Package1SignatureRequired = new Package(4, 4, 4, 5, 0, null, true);
+            Package2 = new Package(6, 6, 6, 5, 100);
 
             USPSUserId = ConfigurationManager.AppSettings["USPSUserId"];
         }
@@ -132,6 +134,41 @@ namespace DotNetShipping.Tests.Features
 
             Assert.NotNull(serviceCodes);
             Assert.NotEmpty(serviceCodes);
+        }
+
+        [Fact]
+        public void Can_Get_Different_Rates_For_Signature_Required_Lookup()
+        {
+            var rateManager = new RateManager();
+            rateManager.AddProvider(new USPSProvider(USPSUserId, "Priority Mail"));
+
+            var nonSignatureResponse = rateManager.GetRates(DomesticAddress1, DomesticAddress2, Package1);
+            var signatureResponse = rateManager.GetRates(DomesticAddress1, DomesticAddress2, Package1SignatureRequired);
+
+            // Assert that we have a non-signature response
+            Assert.NotNull(nonSignatureResponse);
+            Assert.NotEmpty(nonSignatureResponse.Rates);
+            Assert.Empty(nonSignatureResponse.ServerErrors);
+            Assert.True(nonSignatureResponse.Rates.First().TotalCharges > 0);
+
+            // Assert that we have a signature response
+            Assert.NotNull(signatureResponse);
+            Assert.NotEmpty(signatureResponse.Rates);
+            Assert.Empty(signatureResponse.ServerErrors);
+            Assert.True(signatureResponse.Rates.First().TotalCharges > 0);
+
+            // Now compare prices
+            foreach (var signatureRate in signatureResponse.Rates)
+            {
+                var nonSignatureRate = nonSignatureResponse.Rates.FirstOrDefault(x => x.Name == signatureRate.Name);
+
+                if (nonSignatureRate != null)
+                {
+                    var signatureTotalCharges = signatureRate.TotalCharges;
+                    var nonSignatureTotalCharges = nonSignatureRate.TotalCharges;
+                    Assert.NotEqual(signatureTotalCharges, nonSignatureTotalCharges);
+                }
+            }
         }
     }
 }

--- a/DotNetShipping/Package.cs
+++ b/DotNetShipping/Package.cs
@@ -16,7 +16,8 @@ namespace DotNetShipping
         /// <param name="weight">The weight of the package, in pounds.</param>
         /// <param name="insuredValue">The insured-value of the package, in dollars.</param>
         /// <param name="container">A specific packaging from a shipping provider. E.g. "LG FLAT RATE BOX" for USPS</param>
-        public Package(int length, int width, int height, int weight, decimal insuredValue, string container = null) : this(length, width, height, (decimal) weight, insuredValue, container)
+        /// <param name="signatureRequiredOnDelivery">If true, will attempt to send this to the appropriate rate provider.</param>
+        public Package(int length, int width, int height, int weight, decimal insuredValue, string container = null, bool signatureRequiredOnDelivery = false) : this(length, width, height, (decimal) weight, insuredValue, container, signatureRequiredOnDelivery)
         {
         }
 
@@ -29,7 +30,8 @@ namespace DotNetShipping
         /// <param name="weight">The weight of the package, in pounds.</param>
         /// <param name="insuredValue">The insured-value of the package, in dollars.</param>
         /// <param name="container">A specific packaging from a shipping provider. E.g. "LG FLAT RATE BOX" for USPS</param>
-        public Package(decimal length, decimal width, decimal height, decimal weight, decimal insuredValue, string container = null)
+        /// <param name="signatureRequiredOnDelivery">If true, will attempt to send this to the appropriate rate provider.</param>
+        public Package(decimal length, decimal width, decimal height, decimal weight, decimal insuredValue, string container = null, bool signatureRequiredOnDelivery = false)
         {
             Length = length;
             Width = width;
@@ -37,6 +39,7 @@ namespace DotNetShipping
             Weight = weight;
             InsuredValue = insuredValue;
             Container = container;
+            SignatureRequiredOnDelivery = signatureRequiredOnDelivery;
         }
 
         public decimal CalculatedGirth
@@ -70,6 +73,7 @@ namespace DotNetShipping
         public decimal Weight { get; set; }
         public decimal Width { get; set; }
         public string Container { get; set; }
+        public bool SignatureRequiredOnDelivery { get; set; }
         public PoundsAndOunces PoundsAndOunces
         {
             get

--- a/DotNetShipping/ShippingProviders/FedExBaseProvider.cs
+++ b/DotNetShipping/ShippingProviders/FedExBaseProvider.cs
@@ -226,6 +226,14 @@ namespace DotNetShipping.ShippingProviders
                     request.RequestedShipment.RequestedPackageLineItems[i].InsuredValue.Currency = "USD";
                 }
 
+                if (package.SignatureRequiredOnDelivery)
+                {
+                    var signatureOptionDetail = new SignatureOptionDetail { OptionType = SignatureOptionType.DIRECT };
+                    var specialServicesRequested = new PackageSpecialServicesRequested() { SignatureOptionDetail = signatureOptionDetail };
+
+                    request.RequestedShipment.RequestedPackageLineItems[i].SpecialServicesRequested = specialServicesRequested;
+                }
+
                 i++;
             }
         }

--- a/DotNetShipping/ShippingProviders/UPSProvider.cs
+++ b/DotNetShipping/ShippingProviders/UPSProvider.cs
@@ -221,6 +221,14 @@ namespace DotNetShipping.ShippingProviders
                 writer.WriteElementString("CurrencyCode", "USD");
                 writer.WriteElementString("MonetaryValue", Shipment.Packages[i].InsuredValue.ToString());
                 writer.WriteEndElement(); // </InsuredValue>
+
+                if (Shipment.Packages[i].SignatureRequiredOnDelivery)
+                {
+                    writer.WriteStartElement("DeliveryConfirmation");
+                    writer.WriteElementString("DCISType", "2");         // 2 represents Delivery Confirmation Signature Required
+                    writer.WriteEndElement(); // </DeliveryConfirmation>
+                }
+
                 writer.WriteEndElement(); // </PackageServiceOptions>
                 writer.WriteEndElement(); // </Package>
             }

--- a/DotNetShipping/ShippingProviders/USPSProvider.cs
+++ b/DotNetShipping/ShippingProviders/USPSProvider.cs
@@ -290,7 +290,7 @@ namespace DotNetShipping.ShippingProviders
                 var name = Regex.Replace(r.Name, "&lt.*&gt;", "");
                 var additionalCharges = 0.0m;
 
-                if (includeSpecialServiceCodes != null && includeSpecialServiceCodes.Count > 0)
+                if (includeSpecialServiceCodes != null && includeSpecialServiceCodes.Count > 0 && r.SpecialServices != null)
                 {
                     var specialServices = r.SpecialServices.XPathSelectElements("SpecialService").ToList();
                     if (specialServices.Count > 0)


### PR DESCRIPTION
…confirmation. By default this feature is off and will use the base functionality currently provided by DotNetShipping. However, when instantiating a new Package, just set the SignatureRequiredOnDelivery to true. Unit tests have ben wired up for USPS, UPS and FedEx. Currently the only caveat is w/ USPS. If you're doing an ALL lookup (which is the default), the additional service charges will *not* be returned. The only way to get those charges is to do a specific service lookup (which will then have the additional charges returned). This is a limitation of the USPS API and unfortunately isn't an easy fix. Just as an aside, the average cost of the signature confirmation for most of the carriers is about $4-$5 as of 2/20/2017.