### PR TITLE
Use exact Weight in FedEx carrier instead of RoundWeight, added a way to specify FedEx that we want to use Account Rates instead of Listed rates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@
 packages/
 
 #Visual Studio files
+.vs/
 *.[Oo]bj
 *.user
 *.aps

--- a/DotNetShipping.Tests/Features/FedExShipRates.cs
+++ b/DotNetShipping.Tests/Features/FedExShipRates.cs
@@ -53,6 +53,20 @@ namespace DotNetShipping.Tests.Features
         }
 
         [Fact]
+        public void FedExReturnsRates_WithPackageWithDecimals()
+        {
+            var from = new Address("Quebec", "QC", "G1K6T3", "CA");
+            var to = new Address("Quebec", "QC", "G1H2T5", "CA");
+            var package = new Package(0.5m, 0.5m, 0.5m, 0.1m, 0m);
+
+            var r = _rateManager.GetRates(from, to, package);
+            var fedExRates = r.Rates.ToList();
+
+            Assert.NotNull(r);
+            Assert.True(fedExRates.Any());
+        }
+
+        [Fact]
         public void FedExReturnsDifferentRatesForSignatureOnDelivery()
         {
             var from = new Address("Annapolis", "MD", "21401", "US");

--- a/DotNetShipping/Package.cs
+++ b/DotNetShipping/Package.cs
@@ -92,5 +92,6 @@ namespace DotNetShipping
                 return poundsAndOunces;
             }
         }
+        public string Currency { get; set; }
     }
 }

--- a/DotNetShipping/ShippingProviders/FedExBaseProvider.cs
+++ b/DotNetShipping/ShippingProviders/FedExBaseProvider.cs
@@ -196,6 +196,7 @@ namespace DotNetShipping.ShippingProviders
         protected void SetPackageLineItems(RateRequest request)
         {
             request.RequestedShipment.RequestedPackageLineItems = new RequestedPackageLineItem[Shipment.PackageCount];
+            request.RequestedShipment.PreferredCurrency = Shipment.Packages.FirstOrDefault()?.Currency ?? "USD";
 
             var i = 0;
             foreach (var package in Shipment.Packages)

--- a/DotNetShipping/ShippingProviders/FedExBaseProvider.cs
+++ b/DotNetShipping/ShippingProviders/FedExBaseProvider.cs
@@ -17,7 +17,9 @@ namespace DotNetShipping.ShippingProviders
         protected string _key;
 		protected string _meterNumber;
         protected string _password;
+
         protected bool _useProduction = true;
+
         protected Dictionary<string, string> _serviceCodes;
 
         /// <summary>
@@ -223,7 +225,7 @@ namespace DotNetShipping.ShippingProviders
                     {
                         Amount = package.InsuredValue,
                         AmountSpecified = true,
-                        Currency = "USD"
+                        Currency = package.Currency ?? "USD"
                     };
                 }
 

--- a/DotNetShipping/ShippingProviders/FedExBaseProvider.cs
+++ b/DotNetShipping/ShippingProviders/FedExBaseProvider.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Configuration;
 using System.Diagnostics;
+using System.Globalization;
 using System.Linq;
 using System.Text;
 using System.Web.Services.Protocols;
@@ -208,9 +209,9 @@ namespace DotNetShipping.ShippingProviders
                     },
                     Dimensions = new Dimensions
                     {
-                        Length = package.Length.ToString(),
-                        Width = package.Width.ToString(),
-                        Height = package.Height.ToString(),
+                        Length = package.RoundedLength.ToString("0.##", CultureInfo.InvariantCulture),
+                        Width = package.RoundedWidth.ToString("0.##", CultureInfo.InvariantCulture),
+                        Height = package.RoundedHeight.ToString("0.##", CultureInfo.InvariantCulture),
                         Units = LinearUnits.IN
                     }
                 };

--- a/DotNetShipping/ShippingProviders/FedExBaseProvider.cs
+++ b/DotNetShipping/ShippingProviders/FedExBaseProvider.cs
@@ -197,27 +197,33 @@ namespace DotNetShipping.ShippingProviders
             var i = 0;
             foreach (var package in Shipment.Packages)
             {
-                request.RequestedShipment.RequestedPackageLineItems[i] = new RequestedPackageLineItem();
-                request.RequestedShipment.RequestedPackageLineItems[i].SequenceNumber = (i + 1).ToString();
-                request.RequestedShipment.RequestedPackageLineItems[i].GroupPackageCount = "1";
-                // package weight
-                request.RequestedShipment.RequestedPackageLineItems[i].Weight = new Weight();
-                request.RequestedShipment.RequestedPackageLineItems[i].Weight.Units = WeightUnits.LB;
-                request.RequestedShipment.RequestedPackageLineItems[i].Weight.Value = package.RoundedWeight;
-                // package dimensions
-                request.RequestedShipment.RequestedPackageLineItems[i].Dimensions = new Dimensions();
-                request.RequestedShipment.RequestedPackageLineItems[i].Dimensions.Length = package.RoundedLength.ToString();
-                request.RequestedShipment.RequestedPackageLineItems[i].Dimensions.Width = package.RoundedWidth.ToString();
-                request.RequestedShipment.RequestedPackageLineItems[i].Dimensions.Height = package.RoundedHeight.ToString();
-                request.RequestedShipment.RequestedPackageLineItems[i].Dimensions.Units = LinearUnits.IN;
+                request.RequestedShipment.RequestedPackageLineItems[i] = new RequestedPackageLineItem
+                {
+                    SequenceNumber = (i + 1).ToString(),
+                    GroupPackageCount = "1",
+                    Weight = new Weight
+                    {
+                        Units = WeightUnits.LB,
+                        Value = package.Weight
+                    },
+                    Dimensions = new Dimensions
+                    {
+                        Length = package.Length.ToString(),
+                        Width = package.Width.ToString(),
+                        Height = package.Height.ToString(),
+                        Units = LinearUnits.IN
+                    }
+                };
 
                 if (_allowInsuredValues)
                 {
                     // package insured value
-                    request.RequestedShipment.RequestedPackageLineItems[i].InsuredValue = new Money();
-                    request.RequestedShipment.RequestedPackageLineItems[i].InsuredValue.Amount = package.InsuredValue;
-                    request.RequestedShipment.RequestedPackageLineItems[i].InsuredValue.AmountSpecified = true;
-                    request.RequestedShipment.RequestedPackageLineItems[i].InsuredValue.Currency = "USD";
+                    request.RequestedShipment.RequestedPackageLineItems[i].InsuredValue = new Money
+                    {
+                        Amount = package.InsuredValue,
+                        AmountSpecified = true,
+                        Currency = "USD"
+                    };
                 }
 
                 if (package.SignatureRequiredOnDelivery)


### PR DESCRIPTION
The actual FedEx implementation uses `RoundedWeight`, however, sometimes package can weight less than 1 lbs and FedEx supports it already. So we get higher rates than expected. This PR fixes it.

I also added a way to specify to FedEx that we want to use Account rates instead of Listed rates.